### PR TITLE
feat: add input history, ID-based sorting, and loading states to comparator

### DIFF
--- a/src/lib/components/ComparatorPanel.svelte
+++ b/src/lib/components/ComparatorPanel.svelte
@@ -8,6 +8,11 @@
 	import { comparatorState as cmpState } from '$lib/panelState.svelte';
 
 	let isLogging = $state(false);
+	let server1UrlHistory = $state<string[]>([]);
+	let server2UrlHistory = $state<string[]>([]);
+	let isProcessingData = $state(false);
+	let processingMessage = $state('');
+	let inputHistory = $state<Record<string, string[]>>({});
 
 	const watchedKeys = $derived(
 		cmpState.watchedKeysInput
@@ -78,6 +83,18 @@
 				if (localStorage.server1Base) cmpState.server1Base = localStorage.server1Base;
 				if (localStorage.server2Base) cmpState.server2Base = localStorage.server2Base;
 			}
+
+			// Load URL history
+			try {
+				const s1History = localStorage.getItem('server1UrlHistory');
+				if (s1History) server1UrlHistory = JSON.parse(s1History);
+				const s2History = localStorage.getItem('server2UrlHistory');
+				if (s2History) server2UrlHistory = JSON.parse(s2History);
+			} catch (e) {
+				console.error('Failed to parse URL history', e);
+			}
+
+			loadInputHistory();
 
 			// Load saved params for all endpoints
 			if (Object.keys(cmpState.endpointParams).length === 0 && localStorage.comparatorParams) {
@@ -257,6 +274,45 @@
 		}
 	}
 
+	function saveUrlToHistory(url: string, history: string[]): string[] {
+		if (!url || history.includes(url)) return history;
+		return [url, ...history.filter((u) => u !== url)].slice(0, 5);
+	}
+
+	function getInputHistoryKey(endpointId: string, paramName: string): string {
+		return `${endpointId}:${paramName}`;
+	}
+
+	function getInputHistory(endpointId: string, paramName: string): string[] {
+		const key = getInputHistoryKey(endpointId, paramName);
+		return inputHistory[key] || [];
+	}
+
+	function saveInputToHistory(endpointId: string, paramName: string, value: string) {
+		if (!value.trim()) return;
+		const key = getInputHistoryKey(endpointId, paramName);
+		const history = getInputHistory(endpointId, paramName);
+		if (!history.includes(value)) {
+			inputHistory[key] = [value, ...history].slice(0, 5);
+			if (typeof localStorage !== 'undefined') {
+				localStorage.setItem('inputHistory', JSON.stringify(inputHistory));
+			}
+		}
+	}
+
+	function loadInputHistory() {
+		if (typeof localStorage !== 'undefined') {
+			const saved = localStorage.getItem('inputHistory');
+			if (saved) {
+				try {
+					inputHistory = JSON.parse(saved);
+				} catch {
+					inputHistory = {};
+				}
+			}
+		}
+	}
+
 	async function fetchBoth() {
 		if (cmpState.loading) return;
 		cmpState.loading = true;
@@ -315,6 +371,36 @@
 
 			cmpState.response1 = data.response1;
 			cmpState.response2 = data.response2;
+
+			const dataSize =
+				JSON.stringify(data.response1).length + JSON.stringify(data.response2).length;
+			if (dataSize > 500000) {
+				isProcessingData = true;
+				processingMessage = 'Processing large response...';
+				await new Promise((r) => setTimeout(r, 50));
+			}
+
+			server1UrlHistory = saveUrlToHistory(cmpState.server1Base, server1UrlHistory);
+			server2UrlHistory = saveUrlToHistory(cmpState.server2Base, server2UrlHistory);
+
+			Object.entries(cmpState.params).forEach(([paramName, value]) => {
+				if (value.trim()) {
+					saveInputToHistory(cmpState.selectedEndpoint, paramName, value);
+				}
+			});
+
+			if (typeof localStorage !== 'undefined') {
+				localStorage.setItem('server1UrlHistory', JSON.stringify(server1UrlHistory));
+				localStorage.setItem('server2UrlHistory', JSON.stringify(server2UrlHistory));
+				localStorage.server1Base = cmpState.server1Base;
+				localStorage.server2Base = cmpState.server2Base;
+			}
+
+			if (dataSize > 500000) {
+				processingMessage = 'Rendering comparison...';
+				await new Promise((r) => setTimeout(r, 50));
+				isProcessingData = false;
+			}
 
 			await logWatchedKeys(data.response1, data.response2);
 		} catch (e) {
@@ -387,8 +473,14 @@
 					id="server1-url"
 					type="text"
 					bind:value={cmpState.server1Base}
+					list="server1-url-history"
 					class="w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 font-mono text-sm text-gray-700 transition-all focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:focus:ring-indigo-500/40"
 				/>
+				<datalist id="server1-url-history">
+					{#each server1UrlHistory as url}
+						<option value={url}></option>
+					{/each}
+				</datalist>
 			</div>
 			<div>
 				<label
@@ -400,8 +492,14 @@
 					id="server2-url"
 					type="text"
 					bind:value={cmpState.server2Base}
+					list="server2-url-history"
 					class="w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 font-mono text-sm text-gray-700 transition-all focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:focus:ring-indigo-500/40"
 				/>
+				<datalist id="server2-url-history">
+					{#each server2UrlHistory as url}
+						<option value={url}></option>
+					{/each}
+				</datalist>
 			</div>
 		</div>
 
@@ -426,6 +524,7 @@
 			</div>
 
 			{#each endpoints.find((e) => e.id === cmpState.selectedEndpoint)?.params || [] as param (param.name)}
+				{@const history = getInputHistory(cmpState.selectedEndpoint, param.name)}
 				<div class="col-span-3">
 					<label
 						for={'param-' + param.name}
@@ -440,8 +539,16 @@
 						value={cmpState.params[param.name] || ''}
 						oninput={(e) => handleParamChange(param.name, e.currentTarget.value)}
 						placeholder={param.placeholder || ''}
+						list={'param-history-' + param.name}
 						class="w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-700 transition-all focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:focus:ring-indigo-500/40"
 					/>
+					{#if history.length > 0}
+						<datalist id={'param-history-' + param.name}>
+							{#each history as value}
+								<option {value}></option>
+							{/each}
+						</datalist>
+					{/if}
 				</div>
 			{/each}
 
@@ -656,12 +763,34 @@
 		</div>
 	{/if}
 
-	<DiffViewer
-		response1={cmpState.response1}
-		response2={cmpState.response2}
-		focusPath={cmpState.focusPath}
-		{ignoredKeys}
-	/>
+	<div class="relative">
+		{#if isProcessingData}
+			<div
+				class="absolute inset-0 z-50 flex items-center justify-center bg-white/80 backdrop-blur-sm dark:bg-gray-900/80"
+			>
+				<div class="flex flex-col items-center gap-3">
+					<svg class="h-8 w-8 animate-spin text-indigo-600" fill="none" viewBox="0 0 24 24">
+						<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
+						></circle>
+						<path
+							class="opacity-75"
+							fill="currentColor"
+							d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+						></path>
+					</svg>
+					<span class="text-sm font-medium text-gray-700 dark:text-gray-300"
+						>{processingMessage}</span
+					>
+				</div>
+			</div>
+		{/if}
+		<DiffViewer
+			response1={cmpState.response1}
+			response2={cmpState.response2}
+			focusPath={cmpState.focusPath}
+			{ignoredKeys}
+		/>
+	</div>
 {:else if !cmpState.loading}
 	<div
 		class="flex flex-col items-center justify-center rounded-xl border border-gray-200 bg-white p-16 text-center transition-colors duration-300 dark:border-gray-700 dark:bg-gray-800"

--- a/src/lib/components/ComparatorPanel.svelte
+++ b/src/lib/components/ComparatorPanel.svelte
@@ -477,7 +477,7 @@
 					class="w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 font-mono text-sm text-gray-700 transition-all focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:focus:ring-indigo-500/40"
 				/>
 				<datalist id="server1-url-history">
-					{#each server1UrlHistory as url}
+					{#each server1UrlHistory as url (url)}
 						<option value={url}></option>
 					{/each}
 				</datalist>
@@ -496,7 +496,7 @@
 					class="w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 font-mono text-sm text-gray-700 transition-all focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:focus:ring-indigo-500/40"
 				/>
 				<datalist id="server2-url-history">
-					{#each server2UrlHistory as url}
+					{#each server2UrlHistory as url (url)}
 						<option value={url}></option>
 					{/each}
 				</datalist>
@@ -544,7 +544,7 @@
 					/>
 					{#if history.length > 0}
 						<datalist id={'param-history-' + param.name}>
-							{#each history as value}
+							{#each history as value (value)}
 								<option {value}></option>
 							{/each}
 						</datalist>

--- a/src/lib/components/DiffViewer.svelte
+++ b/src/lib/components/DiffViewer.svelte
@@ -2,7 +2,7 @@
 	import JsonViewer from './JsonViewer.svelte';
 	import { getByPath } from '$lib/utils/jsonCompare';
 	import { deepSearchJSON } from '$lib/utils/search';
-	import { SvelteSet } from 'svelte/reactivity';
+	import { SvelteSet, SvelteMap } from 'svelte/reactivity';
 
 	interface Props {
 		response1: unknown;
@@ -37,7 +37,7 @@
 
 		const ID_FIELDS = ['tripId', 'id', 'activeTripId', 'routeId', 'stopId', 'vehicleId', 'blockId'];
 
-		function getId(item: any): string {
+		function getId(item: Record<string, unknown>): string {
 			for (const field of ID_FIELDS) {
 				if (item && typeof item[field] === 'string' && item[field]) {
 					return item[field];
@@ -49,7 +49,7 @@
 			return JSON.stringify(item);
 		}
 
-		function findArray(data: any): any[] {
+		function findArray(data: unknown): unknown[] {
 			if (!data) return [];
 			if (Array.isArray(data)) return data;
 
@@ -68,11 +68,11 @@
 			}
 
 			// Search recursively for first array with objects having IDs
-			function search(obj: any): any[] | null {
+			function search(obj: unknown): unknown[] | null {
 				if (!obj || typeof obj !== 'object') return null;
 				if (Array.isArray(obj)) return obj.length > 0 ? obj : null;
 
-				for (const value of Object.values(obj)) {
+				for (const value of Object.values(obj as Record<string, unknown>)) {
 					const result = search(value);
 					if (result) return result;
 				}
@@ -87,19 +87,19 @@
 
 		if (arr1.length > 0 && arr2.length > 0) {
 			// Create matched pairs by ID
-			const leftMap = new Map();
-			const rightMap = new Map();
+			const leftMap = new SvelteMap<string, unknown[]>();
+			const rightMap = new SvelteMap<string, unknown[]>();
 
 			for (const item of arr1) {
-				const id = getId(item);
+				const id = getId(item as Record<string, unknown>);
 				if (!leftMap.has(id)) leftMap.set(id, []);
-				leftMap.get(id).push(item);
+				leftMap.get(id)!.push(item);
 			}
 
 			for (const item of arr2) {
-				const id = getId(item);
+				const id = getId(item as Record<string, unknown>);
 				if (!rightMap.has(id)) rightMap.set(id, []);
-				rightMap.get(id).push(item);
+				rightMap.get(id)!.push(item);
 			}
 
 			// Get all unique IDs

--- a/src/lib/components/DiffViewer.svelte
+++ b/src/lib/components/DiffViewer.svelte
@@ -17,6 +17,116 @@
 	const focused1 = $derived(trimmedPath ? getByPath(response1, trimmedPath) : response1);
 	const focused2 = $derived(trimmedPath ? getByPath(response2, trimmedPath) : response2);
 
+	let sorted1 = $state<unknown>(null);
+	let sorted2 = $state<unknown>(null);
+	let sortLoading = $state(false);
+	let sortEnabled = $state(false);
+
+	async function doSort() {
+		if (sortEnabled) {
+			// Revert to original
+			sorted1 = null;
+			sorted2 = null;
+			sortEnabled = false;
+			return;
+		}
+
+		sortLoading = true;
+		sortEnabled = true;
+		await new Promise((r) => setTimeout(r, 0));
+
+		const ID_FIELDS = ['tripId', 'id', 'activeTripId', 'routeId', 'stopId', 'vehicleId', 'blockId'];
+
+		function getId(item: any): string {
+			for (const field of ID_FIELDS) {
+				if (item && typeof item[field] === 'string' && item[field]) {
+					return item[field];
+				}
+				if (item && typeof item[field] === 'number') {
+					return String(item[field]);
+				}
+			}
+			return JSON.stringify(item);
+		}
+
+		function findArray(data: any): any[] {
+			if (!data) return [];
+			if (Array.isArray(data)) return data;
+
+			// Search for array in common locations
+			const keys = ['list', 'data', 'items', 'results', 'elements', 'entities'];
+			for (const key of keys) {
+				if (data[key] && Array.isArray(data[key]) && data[key].length > 0) {
+					// Check if first item has an ID field
+					const firstItem = data[key][0];
+					if (firstItem && typeof firstItem === 'object') {
+						for (const idField of ID_FIELDS) {
+							if (firstItem[idField]) return data[key];
+						}
+					}
+				}
+			}
+
+			// Search recursively for first array with objects having IDs
+			function search(obj: any): any[] | null {
+				if (!obj || typeof obj !== 'object') return null;
+				if (Array.isArray(obj)) return obj.length > 0 ? obj : null;
+
+				for (const value of Object.values(obj)) {
+					const result = search(value);
+					if (result) return result;
+				}
+				return null;
+			}
+
+			return search(data) || [];
+		}
+
+		const arr1 = findArray(focused1);
+		const arr2 = findArray(focused2);
+
+		if (arr1.length > 0 && arr2.length > 0) {
+			// Create matched pairs by ID
+			const leftMap = new Map();
+			const rightMap = new Map();
+
+			for (const item of arr1) {
+				const id = getId(item);
+				if (!leftMap.has(id)) leftMap.set(id, []);
+				leftMap.get(id).push(item);
+			}
+
+			for (const item of arr2) {
+				const id = getId(item);
+				if (!rightMap.has(id)) rightMap.set(id, []);
+				rightMap.get(id).push(item);
+			}
+
+			// Get all unique IDs
+			const allIds = new Set([...leftMap.keys(), ...rightMap.keys()]);
+
+			const matched1 = [];
+			const matched2 = [];
+
+			// First add matching IDs (items that exist on both sides)
+			for (const id of allIds) {
+				const items1 = leftMap.get(id) || [];
+				const items2 = rightMap.get(id) || [];
+				const maxLen = Math.max(items1.length, items2.length);
+
+				for (let i = 0; i < maxLen; i++) {
+					matched1.push(items1[i] || null);
+					matched2.push(items2[i] || null);
+				}
+			}
+
+			sorted1 = matched1;
+			sorted2 = matched2;
+		}
+
+		sortLoading = false;
+	}
+
 	let localSearchQuery = $state('');
 	let debouncedSearchQuery = $state('');
 	let isSearching = $state(false);
@@ -204,6 +314,34 @@
 		Sync Select
 	</button>
 
+	<button
+		onclick={doSort}
+		disabled={sortLoading}
+		class="flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition-all {sortEnabled
+			? 'border-indigo-200 bg-indigo-50 text-indigo-700 dark:border-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-400'
+			: 'border-gray-200 bg-gray-50 text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400'}"
+		title="Sort arrays by ID to align matching items"
+	>
+		{#if sortLoading}
+			<svg class="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+				<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
+				></circle>
+				<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+				></path>
+			</svg>
+		{:else}
+			<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="2"
+					d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"
+				></path>
+			</svg>
+		{/if}
+		{sortEnabled ? 'Reset' : 'Sort by ID'}
+	</button>
+
 	{#if debouncedSearchQuery}
 		<div class="flex items-center gap-3 text-sm">
 			{#if totalMatches > 0}
@@ -258,8 +396,8 @@
 		class="max-h-[800px] overflow-auto bg-white dark:bg-gray-900"
 	>
 		<JsonViewer
-			data={focused1}
-			otherData={focused2}
+			data={sorted1 ?? focused1}
+			otherData={sorted2 ?? focused2}
 			{focusPath}
 			{ignoredKeys}
 			mode="server1"
@@ -275,7 +413,7 @@
 		class="max-h-[800px] overflow-auto border-l border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
 	>
 		<JsonViewer
-			data={focused2}
+			data={sorted2 ?? focused2}
 			otherData={focused1}
 			{focusPath}
 			{ignoredKeys}

--- a/src/lib/components/JsonTree.svelte
+++ b/src/lib/components/JsonTree.svelte
@@ -30,6 +30,7 @@
 
 	const CHUNK_SIZE = 50;
 	const LARGE_THRESHOLD = 100;
+	const ROOT_CHUNK_SIZE = 20;
 
 	let {
 		value,
@@ -102,7 +103,8 @@
 	});
 
 	let manualExpanded = $state<boolean | null>(null);
-	let visibleCount = $state(CHUNK_SIZE);
+	let initialChunkSize = $state(level === 0 ? ROOT_CHUNK_SIZE : CHUNK_SIZE);
+	let visibleCount = $state(initialChunkSize);
 	let isLoadingMore = $state(false);
 
 	let lastSearchQuery = $state('');

--- a/src/lib/components/ProtobufViewer.svelte
+++ b/src/lib/components/ProtobufViewer.svelte
@@ -795,6 +795,13 @@
 												{vehicleInfo?.id || vehicleInfo?.label}
 											</span>
 										{/if}
+										{#if trip?.scheduleRelationship}
+											<span
+												class="rounded bg-blue-100 px-2 py-0.5 text-xs text-blue-700 dark:bg-blue-900/50 dark:text-blue-400"
+											>
+												{trip.scheduleRelationship}
+											</span>
+										{/if}
 									{:else if protobufState.activeTab === 'vehiclePositions'}
 										{@const vehicle = item as Record<string, unknown>}
 										{@const vehicleInfo = vehicle.vehicle as Record<string, string> | undefined}

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -1,5 +1,28 @@
 export const endpoints = [
 	{
+		id: 'trip',
+		name: 'Trip',
+		path: 'trip/{id}.json',
+		params: [
+			{
+				name: 'id',
+				label: 'Trip ID',
+				required: true,
+				inPath: true,
+				default: '',
+				placeholder: 'e.g., 1_605425455'
+			},
+			{
+				name: 'key',
+				label: 'API Key',
+				required: true,
+				inPath: false,
+				default: 'test',
+				placeholder: 'API Key'
+			}
+		]
+	},
+	{
 		id: 'trip-details',
 		name: 'Trip Details',
 		path: 'trip-details/{id}.json',

--- a/src/lib/utils/jsonCompare.ts
+++ b/src/lib/utils/jsonCompare.ts
@@ -1,16 +1,29 @@
 export type DiffStatus = 'same' | 'different' | 'missing' | 'added';
 
-const stringifyCache = new WeakMap<object, Map<string, string>>();
+const ID_FIELDS = [
+	'id',
+	'tripId',
+	'activeTripId',
+	'tripId',
+	'routeId',
+	'stopId',
+	'vehicleId',
+	'blockId',
+	'serviceId',
+	'calendarId'
+];
 
-const equalityCache = new WeakMap<object, WeakMap<object, boolean>>();
-
-let cacheCleanupScheduled = false;
-function scheduleCacheCleanup() {
-	if (cacheCleanupScheduled) return;
-	cacheCleanupScheduled = true;
-	setTimeout(() => {
-		cacheCleanupScheduled = false;
-	}, 60000);
+export function findIdValue(item: unknown): string | number | null {
+	if (!isObject(item)) return null;
+	for (const field of ID_FIELDS) {
+		const value = (item as Record<string, unknown>)[field];
+		if (value !== null && value !== undefined) {
+			if (typeof value === 'string' || typeof value === 'number') {
+				return value;
+			}
+		}
+	}
+	return null;
 }
 
 export function isArray(value: unknown): value is unknown[] {
@@ -24,6 +37,8 @@ export function isObject(value: unknown): value is Record<string, unknown> {
 export function isPrimitive(value: unknown): boolean {
 	return !isArray(value) && !isObject(value);
 }
+
+const stringifyCache = new WeakMap<object, Map<string, string>>();
 
 function stableStringifyImpl(value: unknown, ignoredKeys: string[] = []): string {
 	if (value === null) return 'null';
@@ -60,10 +75,104 @@ function stableStringify(value: unknown, ignoredKeys: string[] = []): string {
 			stringifyCache.set(value, objCache);
 		}
 		objCache.set(cacheKey, result);
-		scheduleCacheCleanup();
 		return result;
 	}
 	return stableStringifyImpl(value, ignoredKeys);
+}
+
+export function sortById(a: unknown, b: unknown): number {
+	const aId = findIdValue(a);
+	const bId = findIdValue(b);
+	if (aId !== null && bId !== null) {
+		if (typeof aId === 'number' && typeof bId === 'number') {
+			return aId - bId;
+		}
+		return String(aId).localeCompare(String(bId));
+	}
+	return stableStringify(a).localeCompare(stableStringify(b));
+}
+
+export function sortTopLevelArrays(obj: unknown): unknown {
+	if (!isObject(obj)) return obj;
+
+	const result: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(obj)) {
+		if (isArray(value)) {
+			const hasObjectsWithIds =
+				value.length > 0 && value.some((item) => isObject(item) && findIdValue(item) !== null);
+			if (hasObjectsWithIds) {
+				result[key] = [...value].sort(sortById);
+			} else {
+				result[key] = value;
+			}
+		} else {
+			result[key] = value;
+		}
+	}
+	return result;
+}
+
+export async function sortArrayAsync(arr: unknown[]): Promise<unknown[]> {
+	if (!Array.isArray(arr) || arr.length === 0) return arr;
+
+	const hasObjectsWithIds = arr.some((item) => isObject(item) && findIdValue(item) !== null);
+	if (!hasObjectsWithIds) return arr;
+
+	return [...arr].sort(sortById);
+}
+
+export function matchArraysById(
+	left: unknown[],
+	right: unknown[]
+): { left: unknown; right: unknown; id: string | number | null }[] {
+	const leftMap = new Map<string | number | null, unknown[]>();
+	const rightMap = new Map<string | number | null, unknown[]>();
+
+	for (const item of left) {
+		const id = findIdValue(item);
+		if (!leftMap.has(id)) {
+			leftMap.set(id, []);
+		}
+		leftMap.get(id)!.push(item);
+	}
+
+	for (const item of right) {
+		const id = findIdValue(item);
+		if (!rightMap.has(id)) {
+			rightMap.set(id, []);
+		}
+		rightMap.get(id)!.push(item);
+	}
+
+	const allIds = new Set([...leftMap.keys(), ...rightMap.keys()]);
+	const results: { left: unknown; right: unknown; id: string | number | null }[] = [];
+
+	for (const id of allIds) {
+		const leftItems = leftMap.get(id) || [];
+		const rightItems = rightMap.get(id) || [];
+		const maxLen = Math.max(leftItems.length, rightItems.length);
+
+		for (let i = 0; i < maxLen; i++) {
+			results.push({
+				left: leftItems[i] ?? null,
+				right: rightItems[i] ?? null,
+				id
+			});
+		}
+	}
+
+	return results;
+}
+
+const equalityCache = new WeakMap<object, WeakMap<object, boolean>>();
+
+let cacheCleanupScheduled = false;
+function scheduleCacheCleanup() {
+	if (cacheCleanupScheduled) return;
+	cacheCleanupScheduled = true;
+	setTimeout(() => {
+		cacheCleanupScheduled = false;
+	}, 60000);
 }
 
 export function deepEqualIgnoreOrder(a: unknown, b: unknown, ignoredKeys: string[] = []): boolean {
@@ -87,8 +196,8 @@ export function deepEqualIgnoreOrder(a: unknown, b: unknown, ignoredKeys: string
 		} else if (a.length === 0) {
 			result = true;
 		} else {
-			const aSorted = a.map((item) => stableStringify(item, ignoredKeys)).sort();
-			const bSorted = b.map((item) => stableStringify(item, ignoredKeys)).sort();
+			const aSorted = a.map((item) => stableStringify(item, ignoredKeys)).sort(sortById);
+			const bSorted = b.map((item) => stableStringify(item, ignoredKeys)).sort(sortById);
 			result = aSorted.every((value, index) => value === bSorted[index]);
 		}
 	} else if (isObject(a) && isObject(b)) {
@@ -168,8 +277,8 @@ export function countDifferences(
 			}
 		}
 
-		const aSorted = a.map((item) => stableStringify(item, ignoredKeys)).sort();
-		const bSorted = b.map((item) => stableStringify(item, ignoredKeys)).sort();
+		const aSorted = a.map((item) => stableStringify(item, ignoredKeys)).sort(sortById);
+		const bSorted = b.map((item) => stableStringify(item, ignoredKeys)).sort(sortById);
 		let i = 0;
 		let j = 0;
 		let diff = 0;
@@ -218,7 +327,7 @@ export function sortArrayValues(values: unknown[]): unknown[] {
 	if (values.length > 500) {
 		return values;
 	}
-	return [...values].sort((a, b) => stableStringify(a).localeCompare(stableStringify(b)));
+	return [...values].sort(sortById);
 }
 
 export function parsePath(path: string): (string | number)[] {

--- a/src/lib/utils/search.ts
+++ b/src/lib/utils/search.ts
@@ -227,6 +227,7 @@ export function filterGTFSEntities<T extends unknown[]>(
 				tripUpdate.id?.toLowerCase().includes(lowerQuery) ||
 				tripUpdate.trip?.tripId?.toLowerCase().includes(lowerQuery) ||
 				tripUpdate.trip?.routeId?.toLowerCase().includes(lowerQuery) ||
+				tripUpdate.trip?.scheduleRelationship?.toLowerCase().includes(lowerQuery) ||
 				tripUpdate.vehicle?.id?.toLowerCase().includes(lowerQuery) ||
 				tripUpdate.vehicle?.label?.toLowerCase().includes(lowerQuery)
 			);


### PR DESCRIPTION
Fix: #30 


### Summary

- Add URL and input parameter history with localStorage persistence
- Implement "Sort by ID" feature to align matching items in diff viewer
- Add loading overlay for large data processing
- Add new Trip endpoint and scheduleRelationship search support

### Changes

**ComparatorPanel.svelte**

- Persist server URLs to history (last 5 URLs each)
- Persist parameter input values with endpoint-specific keys
- Display datalist dropdowns for URL and parameter suggestions
- Show loading overlay when processing large responses (>500KB)

**DiffViewer.svelte**

- Add "Sort by ID" button to sort arrays by ID fields
- Match items across both sides by ID for aligned comparison
- Toggle between sorted and original view

**JsonTree.svelte**

- Reduced initial root chunk size for better performance

**ProtobufViewer.svelte**

- Display `scheduleRelationship` badge in trip info

**endpoints.ts**

- Add new Trip endpoint

**jsonCompare.ts**

- Add ID field detection and sorting utilities
- Add `sortById`, `findIdValue`, `sortTopLevelArrays`, `matchArraysById` functions
- Update existing sort calls to use ID-based sorting