### PR TITLE
feat: add mismatch count and total comparable items to ComparatorPanel, enhance sorting with ignored keys

### DIFF
--- a/src/lib/components/ComparatorPanel.svelte
+++ b/src/lib/components/ComparatorPanel.svelte
@@ -50,12 +50,19 @@
 
 	const diffStats = $derived.by(() => {
 		if (cmpState.response1 === null || cmpState.response2 === null) return null;
-		const total = countComparableItems(cmpState.response1, cmpState.response2, ignoredKeys, MAX_COMPARABLE_BUDGET);
+		const total = countComparableItems(
+			cmpState.response1,
+			cmpState.response2,
+			ignoredKeys,
+			MAX_COMPARABLE_BUDGET
+		);
 		const mismatches = countDifferences(cmpState.response1, cmpState.response2, ignoredKeys);
 		return {
 			total: total.capped ? `${total.count}+` : total.count,
 			mismatches,
-			matches: total.capped ? `${Math.max(total.count - mismatches, 0)}+` : total.count - mismatches,
+			matches: total.capped
+				? `${Math.max(total.count - mismatches, 0)}+`
+				: total.count - mismatches,
 			capped: total.capped
 		};
 	});

--- a/src/lib/components/ComparatorPanel.svelte
+++ b/src/lib/components/ComparatorPanel.svelte
@@ -46,11 +46,18 @@
 			.filter((k) => k.length > 0)
 	);
 
+	const MAX_COMPARABLE_BUDGET = 50000;
+
 	const diffStats = $derived.by(() => {
-		if (!cmpState.response1 || !cmpState.response2) return null;
-		const total = countComparableItems(cmpState.response1, cmpState.response2, ignoredKeys);
+		if (cmpState.response1 === null || cmpState.response2 === null) return null;
+		const total = countComparableItems(cmpState.response1, cmpState.response2, ignoredKeys, MAX_COMPARABLE_BUDGET);
 		const mismatches = countDifferences(cmpState.response1, cmpState.response2, ignoredKeys);
-		return { total, mismatches, matches: total - mismatches };
+		return {
+			total: total.capped ? `${total.count}+` : total.count,
+			mismatches,
+			matches: total.capped ? `${Math.max(total.count - mismatches, 0)}+` : total.count - mismatches,
+			capped: total.capped
+		};
 	});
 
 	const availableKeys = $derived.by(() => {

--- a/src/lib/components/ComparatorPanel.svelte
+++ b/src/lib/components/ComparatorPanel.svelte
@@ -6,7 +6,12 @@
 	import { browser } from '$app/environment';
 	import { logState } from '$lib/logState.svelte';
 	import { comparatorState as cmpState } from '$lib/panelState.svelte';
-	import { sortById, findIdValue } from '$lib/utils/jsonCompare';
+	import {
+		sortById,
+		findIdValue,
+		countDifferences,
+		countComparableItems
+	} from '$lib/utils/jsonCompare';
 
 	let isLogging = $state(false);
 	let server1UrlHistory = $state<string[]>([]);
@@ -40,6 +45,13 @@
 			.map((k) => k.trim())
 			.filter((k) => k.length > 0)
 	);
+
+	const diffStats = $derived.by(() => {
+		if (!cmpState.response1 || !cmpState.response2) return null;
+		const total = countComparableItems(cmpState.response1, cmpState.response2, ignoredKeys);
+		const mismatches = countDifferences(cmpState.response1, cmpState.response2, ignoredKeys);
+		return { total, mismatches, matches: total - mismatches };
+	});
 
 	const availableKeys = $derived.by(() => {
 		const keys = new Set<string>();
@@ -957,6 +969,46 @@
 						>{cmpState.currentUrl2}</code
 					>
 				</div>
+			{/if}
+		</div>
+	{/if}
+
+	{#if diffStats}
+		<div
+			class="mb-4 flex items-center gap-4 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm dark:border-gray-700 dark:bg-gray-800/50"
+		>
+			{#if diffStats.mismatches === 0}
+				<span class="flex items-center gap-1.5 font-medium text-green-700 dark:text-green-400">
+					<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2.5"
+							d="M5 13l4 4L19 7"
+						/>
+					</svg>
+					All {diffStats.total} fields match
+				</span>
+			{:else}
+				<span class="flex items-center gap-1.5 font-medium text-red-600 dark:text-red-400">
+					<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2.5"
+							d="M6 18L18 6M6 6l12 12"
+						/>
+					</svg>
+					{diffStats.mismatches} mismatch{diffStats.mismatches !== 1 ? 'es' : ''}
+				</span>
+				<span class="text-gray-500 dark:text-gray-400">
+					{diffStats.matches} / {diffStats.total} match
+				</span>
+			{/if}
+			{#if ignoredKeys.length > 0}
+				<span class="ml-auto text-xs text-gray-400 dark:text-gray-500">
+					({ignoredKeys.length} key{ignoredKeys.length !== 1 ? 's' : ''} ignored)
+				</span>
 			{/if}
 		</div>
 	{/if}

--- a/src/lib/utils/jsonCompare.ts
+++ b/src/lib/utils/jsonCompare.ts
@@ -468,7 +468,13 @@ export function countComparableItems(
 				continue;
 			}
 			if (budget <= 0) return { count, capped: true };
-			const sub = countComparableItems(aItems[i].item, bItems[j].item, ignoredKeys, budget, itemPath);
+			const sub = countComparableItems(
+				aItems[i].item,
+				bItems[j].item,
+				ignoredKeys,
+				budget,
+				itemPath
+			);
 			count += sub.count;
 			budget -= sub.count;
 			if (sub.capped) capped = true;

--- a/src/lib/utils/jsonCompare.ts
+++ b/src/lib/utils/jsonCompare.ts
@@ -102,6 +102,11 @@ function stableStringify(
 	return stableStringifyImpl(value, ignoredKeys, currentPath);
 }
 
+function isIdFieldIgnoredAtPath(currentPath: string, ignoredKeys: string[]): boolean {
+	if (ignoredKeys.length === 0) return false;
+	return ID_FIELDS.some((field) => isKeyIgnored(field, currentPath, ignoredKeys));
+}
+
 export function sortById(
 	a: unknown,
 	b: unknown,
@@ -110,7 +115,7 @@ export function sortById(
 ): number {
 	const aId = findIdValue(a);
 	const bId = findIdValue(b);
-	if (aId !== null && bId !== null) {
+	if (aId !== null && bId !== null && !isIdFieldIgnoredAtPath(currentPath, ignoredKeys)) {
 		if (typeof aId === 'number' && typeof bId === 'number') {
 			return aId - bId;
 		}
@@ -425,20 +430,52 @@ export function countComparableItems(
 	a: unknown,
 	b: unknown,
 	ignoredKeys: string[] = [],
+	budget: number = 99999,
 	currentPath: string = ''
-): number {
-	if (a === undefined && b === undefined) return 0;
-	if (a === undefined || b === undefined) return 1;
-	if (isPrimitive(a) || isPrimitive(b)) return 1;
+): { count: number; capped: boolean } {
+	if (a === undefined && b === undefined) return { count: 0, capped: false };
+	if (a === undefined || b === undefined) return { count: 1, capped: false };
+	if (isPrimitive(a) || isPrimitive(b)) return { count: 1, capped: false };
+	if (budget <= 0) return { count: 0, capped: true };
 
 	if (isArray(a) && isArray(b)) {
 		const itemPath = currentPath ? `${currentPath}.*` : '*';
-		const maxLen = Math.max(a.length, b.length);
+		const aItems = a.map((item) => ({ key: stableStringify(item, ignoredKeys, itemPath), item }));
+		const bItems = b.map((item) => ({ key: stableStringify(item, ignoredKeys, itemPath), item }));
+		aItems.sort((x, y) => sortById(x.item, y.item, ignoredKeys, itemPath));
+		bItems.sort((x, y) => sortById(x.item, y.item, ignoredKeys, itemPath));
+
 		let count = 0;
-		for (let i = 0; i < maxLen; i++) {
-			count += countComparableItems(a[i], b[i], ignoredKeys, itemPath);
+		let i = 0;
+		let j = 0;
+		let capped = false;
+		while ((i < aItems.length || j < bItems.length) && !capped) {
+			if (budget <= 0) return { count, capped: true };
+			if (i >= aItems.length) {
+				const sub = countComparableItems(null, bItems[j].item, ignoredKeys, budget - 1, itemPath);
+				count += sub.count;
+				capped = sub.capped;
+				j += 1;
+				budget -= sub.count + 1;
+				continue;
+			}
+			if (j >= bItems.length) {
+				const sub = countComparableItems(aItems[i].item, null, ignoredKeys, budget - 1, itemPath);
+				count += sub.count;
+				capped = sub.capped;
+				i += 1;
+				budget -= sub.count + 1;
+				continue;
+			}
+			if (budget <= 0) return { count, capped: true };
+			const sub = countComparableItems(aItems[i].item, bItems[j].item, ignoredKeys, budget, itemPath);
+			count += sub.count;
+			budget -= sub.count;
+			if (sub.capped) capped = true;
+			i += 1;
+			j += 1;
 		}
-		return count;
+		return { count, capped };
 	}
 
 	if (isObject(a) && isObject(b)) {
@@ -447,20 +484,26 @@ export function countComparableItems(
 			...Object.keys(b as Record<string, unknown>)
 		]);
 		let count = 0;
+		let capped = false;
 		for (const key of allKeys) {
+			if (budget <= 0) return { count, capped: true };
 			if (isKeyIgnored(key, currentPath, ignoredKeys)) continue;
 			const childPath = currentPath ? `${currentPath}.${key}` : key;
-			count += countComparableItems(
+			const sub = countComparableItems(
 				(a as Record<string, unknown>)[key],
 				(b as Record<string, unknown>)[key],
 				ignoredKeys,
+				budget,
 				childPath
 			);
+			count += sub.count;
+			budget -= sub.count;
+			if (sub.capped) capped = true;
 		}
-		return count;
+		return { count, capped };
 	}
 
-	return 1;
+	return { count: 1, capped: false };
 }
 
 export function sortEntries(obj: Record<string, unknown>): [string, unknown][] {

--- a/src/lib/utils/jsonCompare.ts
+++ b/src/lib/utils/jsonCompare.ts
@@ -102,7 +102,12 @@ function stableStringify(
 	return stableStringifyImpl(value, ignoredKeys, currentPath);
 }
 
-export function sortById(a: unknown, b: unknown): number {
+export function sortById(
+	a: unknown,
+	b: unknown,
+	ignoredKeys: string[] = [],
+	currentPath: string = ''
+): number {
 	const aId = findIdValue(a);
 	const bId = findIdValue(b);
 	if (aId !== null && bId !== null) {
@@ -111,7 +116,9 @@ export function sortById(a: unknown, b: unknown): number {
 		}
 		return String(aId).localeCompare(String(bId));
 	}
-	return stableStringify(a).localeCompare(stableStringify(b));
+	return stableStringify(a, ignoredKeys, currentPath).localeCompare(
+		stableStringify(b, ignoredKeys, currentPath)
+	);
 }
 
 export function sortTopLevelArrays(obj: unknown): unknown {
@@ -233,19 +240,21 @@ export function deepEqualIgnoreOrder(
 			result = true;
 		} else {
 			const itemPath = currentPath ? `${currentPath}.*` : '*';
+			const sortWithIgnored = (arr: unknown[]) =>
+				[...arr].sort((x, y) => sortById(x, y, ignoredKeys, itemPath));
 			if (numericTolerancePercent > 0) {
-				const aSorted = [...a].sort(sortById);
-				const bSorted = [...b].sort(sortById);
+				const aSorted = sortWithIgnored(a);
+				const bSorted = sortWithIgnored(b);
 				result = aSorted.every((item, index) =>
 					deepEqualIgnoreOrder(item, bSorted[index], ignoredKeys, numericTolerancePercent, itemPath)
 				);
 			} else {
-				const aSorted = [...a]
-					.sort(sortById)
-					.map((item) => stableStringify(item, ignoredKeys, itemPath));
-				const bSorted = [...b]
-					.sort(sortById)
-					.map((item) => stableStringify(item, ignoredKeys, itemPath));
+				const aSorted = sortWithIgnored(a).map((item) =>
+					stableStringify(item, ignoredKeys, itemPath)
+				);
+				const bSorted = sortWithIgnored(b).map((item) =>
+					stableStringify(item, ignoredKeys, itemPath)
+				);
 				result = aSorted.every((value, index) => value === bSorted[index]);
 			}
 		}
@@ -350,8 +359,8 @@ export function countDifferences(
 
 		const aItems = a.map((item) => ({ key: stableStringify(item, ignoredKeys, itemPath), item }));
 		const bItems = b.map((item) => ({ key: stableStringify(item, ignoredKeys, itemPath), item }));
-		aItems.sort((x, y) => sortById(x.item, y.item));
-		bItems.sort((x, y) => sortById(x.item, y.item));
+		aItems.sort((x, y) => sortById(x.item, y.item, ignoredKeys, itemPath));
+		bItems.sort((x, y) => sortById(x.item, y.item, ignoredKeys, itemPath));
 		let i = 0;
 		let j = 0;
 		let diff = 0;
@@ -410,6 +419,48 @@ export function countDifferences(
 		return Math.min(diff, maxCount);
 	}
 	return deepEqualIgnoreOrder(a, b, ignoredKeys, numericTolerancePercent, currentPath) ? 0 : 1;
+}
+
+export function countComparableItems(
+	a: unknown,
+	b: unknown,
+	ignoredKeys: string[] = [],
+	currentPath: string = ''
+): number {
+	if (a === undefined && b === undefined) return 0;
+	if (a === undefined || b === undefined) return 1;
+	if (isPrimitive(a) || isPrimitive(b)) return 1;
+
+	if (isArray(a) && isArray(b)) {
+		const itemPath = currentPath ? `${currentPath}.*` : '*';
+		const maxLen = Math.max(a.length, b.length);
+		let count = 0;
+		for (let i = 0; i < maxLen; i++) {
+			count += countComparableItems(a[i], b[i], ignoredKeys, itemPath);
+		}
+		return count;
+	}
+
+	if (isObject(a) && isObject(b)) {
+		const allKeys = new Set([
+			...Object.keys(a as Record<string, unknown>),
+			...Object.keys(b as Record<string, unknown>)
+		]);
+		let count = 0;
+		for (const key of allKeys) {
+			if (isKeyIgnored(key, currentPath, ignoredKeys)) continue;
+			const childPath = currentPath ? `${currentPath}.${key}` : key;
+			count += countComparableItems(
+				(a as Record<string, unknown>)[key],
+				(b as Record<string, unknown>)[key],
+				ignoredKeys,
+				childPath
+			);
+		}
+		return count;
+	}
+
+	return 1;
 }
 
 export function sortEntries(obj: Record<string, unknown>): [string, unknown][] {


### PR DESCRIPTION
add mismatch count and total comparable items to ComparatorPanel, enhance sorting with ignored keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a comparison summary banner showing match status, mismatch/match counts, total comparable items (with budget cap), and the number of ignored keys.

* **Bug Fixes**
  * Improved JSON comparison consistency for nested arrays/objects by making ordering and comparison context-aware of ignored keys and the current path.
  * Enhanced comparable-item counting to better reflect ignored fields and asymmetric undefined handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->