### PR TITLE
feat: add interactive TraceChart with zoom/pan/solo/hover + fix reactivity

### DIFF
--- a/src/lib/components/ComparatorPanel.svelte
+++ b/src/lib/components/ComparatorPanel.svelte
@@ -43,6 +43,7 @@
 	let endpointInput = $state('');
 	let showEndpointSuggestions = $state(false);
 	let endpointHighlightIndex = $state(-1);
+	let hideTimeout: ReturnType<typeof setTimeout> | undefined;
 
 	const filteredEndpoints = $derived(
 		endpointInput
@@ -54,6 +55,17 @@
 			: endpoints
 	);
 
+	// sync endpointInput when selectedEndpoint initializes or changes externally
+	let prevSelectedId = $state(cmpState.selectedEndpoint);
+	$effect(() => {
+		const id = cmpState.selectedEndpoint;
+		if (id !== prevSelectedId) {
+			prevSelectedId = id;
+			const ep = endpoints.find((e) => e.id === id);
+			endpointInput = ep?.name || id;
+		}
+	});
+
 	function onEndpointInput(e: Event) {
 		endpointInput = (e.target as HTMLInputElement).value;
 		showEndpointSuggestions = true;
@@ -61,12 +73,18 @@
 	}
 
 	function onEndpointFocus() {
+		if (hideTimeout) clearTimeout(hideTimeout);
+		hideTimeout = undefined;
 		showEndpointSuggestions = true;
 		endpointHighlightIndex = -1;
 	}
 
 	function onEndpointBlur() {
-		setTimeout(() => (showEndpointSuggestions = false), 200);
+		if (hideTimeout) clearTimeout(hideTimeout);
+		hideTimeout = setTimeout(() => {
+			showEndpointSuggestions = false;
+			hideTimeout = undefined;
+		}, 200);
 	}
 
 	function onEndpointKeydown(e: KeyboardEvent) {

--- a/src/lib/components/ComparatorPanel.svelte
+++ b/src/lib/components/ComparatorPanel.svelte
@@ -9,6 +9,7 @@
 	import {
 		sortById,
 		findIdValue,
+		matchArraysById,
 		countDifferences,
 		countComparableItems
 	} from '$lib/utils/jsonCompare';
@@ -21,6 +22,13 @@
 	let inputHistory = $state<Record<string, string[]>>({});
 	let batchIdsInput = $state('');
 	const BATCH_IDS_KEY = 'batchIdsInput';
+	let fetchAbortController = $state<AbortController | null>(null);
+
+	function stopFetch() {
+		if (fetchAbortController) {
+			fetchAbortController.abort();
+		}
+	}
 
 	function saveBatchIds() {
 		if (typeof localStorage !== 'undefined') {
@@ -31,6 +39,58 @@
 	const hasInPathParam = $derived(
 		endpoints.find((e) => e.id === cmpState.selectedEndpoint)?.params.some((p) => p.inPath) ?? false
 	);
+
+	let endpointInput = $state('');
+	let showEndpointSuggestions = $state(false);
+	let endpointHighlightIndex = $state(-1);
+
+	const filteredEndpoints = $derived(
+		endpointInput
+			? endpoints.filter(
+					(e) =>
+						e.name.toLowerCase().includes(endpointInput.toLowerCase()) ||
+						e.id.toLowerCase().includes(endpointInput.toLowerCase())
+				)
+			: endpoints
+	);
+
+	function onEndpointInput(e: Event) {
+		endpointInput = (e.target as HTMLInputElement).value;
+		showEndpointSuggestions = true;
+		endpointHighlightIndex = -1;
+	}
+
+	function onEndpointFocus() {
+		showEndpointSuggestions = true;
+		endpointHighlightIndex = -1;
+	}
+
+	function onEndpointBlur() {
+		setTimeout(() => (showEndpointSuggestions = false), 200);
+	}
+
+	function onEndpointKeydown(e: KeyboardEvent) {
+		if (!showEndpointSuggestions) return;
+		if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			endpointHighlightIndex = Math.min(endpointHighlightIndex + 1, filteredEndpoints.length - 1);
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			endpointHighlightIndex = Math.max(endpointHighlightIndex - 1, 0);
+		} else if (e.key === 'Enter' && endpointHighlightIndex >= 0) {
+			e.preventDefault();
+			selectEndpoint(filteredEndpoints[endpointHighlightIndex].id);
+		} else if (e.key === 'Escape') {
+			showEndpointSuggestions = false;
+		}
+	}
+
+	function selectEndpoint(id: string) {
+		cmpState.selectedEndpoint = id;
+		const ep = endpoints.find((e) => e.id === id);
+		endpointInput = ep?.name || id;
+		showEndpointSuggestions = false;
+	}
 
 	const watchedKeys = $derived(
 		cmpState.watchedKeysInput
@@ -238,14 +298,89 @@
 		return walk(obj, 0);
 	}
 
+	function getAlignedArrayValues(
+		resp1: unknown,
+		resp2: unknown,
+		keyPath: string
+	): { server1Value: unknown; server2Value: unknown } | null {
+		const normalized = keyPath.replace(/\[(\d+)\]/g, '.$1');
+		const parts = normalized.split('.');
+		const starIndex = parts.indexOf('*');
+		if (starIndex === -1) return null;
+
+		function walkToArray(obj: unknown): unknown[] {
+			let current = obj;
+			for (let i = 0; i < starIndex; i++) {
+				const part = parts[i];
+				if (current === null || current === undefined) return [];
+				if (Array.isArray(current)) {
+					const numericIdx = Number(part);
+					if (!Number.isInteger(numericIdx)) return [];
+					current = current[numericIdx];
+				} else if (typeof current === 'object') {
+					current = (current as Record<string, unknown>)[part];
+				} else {
+					return [];
+				}
+			}
+			if (!Array.isArray(current)) return [];
+			return current;
+		}
+
+		const arr1 = walkToArray(resp1);
+		const arr2 = walkToArray(resp2);
+
+		if (arr1.length === 0 && arr2.length === 0) {
+			return { server1Value: [], server2Value: [] };
+		}
+
+		const suffixPath = parts.slice(starIndex + 1).join('.');
+		const hasIds1 = arr1.length > 0 && arr1.every((item) => findIdValue(item) !== null);
+		const hasIds2 = arr2.length > 0 && arr2.every((item) => findIdValue(item) !== null);
+
+		if (hasIds1 && hasIds2) {
+			const matched = matchArraysById(arr1, arr2);
+			const s1Values = matched.map((m) => {
+				if (m.left === null || m.left === undefined) return 'missing';
+				return suffixPath ? getValueByPath(m.left, suffixPath) : m.left;
+			});
+			const s2Values = matched.map((m) => {
+				if (m.right === null || m.right === undefined) return 'missing';
+				return suffixPath ? getValueByPath(m.right, suffixPath) : m.right;
+			});
+			return { server1Value: s1Values, server2Value: s2Values };
+		}
+
+		if (hasIds1) {
+			const sorted1 = [...arr1].sort(sortById);
+			return {
+				server1Value: sorted1.map((item) => (suffixPath ? getValueByPath(item, suffixPath) : item)),
+				server2Value: arr2.map((item) => (suffixPath ? getValueByPath(item, suffixPath) : item))
+			};
+		}
+		if (hasIds2) {
+			const sorted2 = [...arr2].sort(sortById);
+			return {
+				server1Value: arr1.map((item) => (suffixPath ? getValueByPath(item, suffixPath) : item)),
+				server2Value: sorted2.map((item) => (suffixPath ? getValueByPath(item, suffixPath) : item))
+			};
+		}
+
+		return null;
+	}
+
 	async function logWatchedKeys(resp1: unknown, resp2: unknown, idValue?: string) {
 		if (watchedKeys.length === 0) return;
 
-		const keys = watchedKeys.map((keyPath) => ({
-			path: keyPath,
-			server1Value: getValueByPath(resp1, keyPath),
-			server2Value: getValueByPath(resp2, keyPath)
-		}));
+		const keys = watchedKeys.map((keyPath) => {
+			const aligned = getAlignedArrayValues(resp1, resp2, keyPath);
+			if (aligned) return { path: keyPath, ...aligned };
+			return {
+				path: keyPath,
+				server1Value: getValueByPath(resp1, keyPath),
+				server2Value: getValueByPath(resp2, keyPath)
+			};
+		});
 
 		try {
 			isLogging = true;
@@ -395,6 +530,9 @@
 			return;
 		}
 
+		fetchAbortController = new AbortController();
+		const globalSignal = fetchAbortController.signal;
+
 		const batchResults = new SvelteMap<
 			string,
 			{
@@ -413,17 +551,27 @@
 			const url1 = buildUrl(cmpState.server1Base, endpoint, params);
 			const url2 = buildUrl(cmpState.server2Base, endpoint, params);
 
-			const controller = new AbortController();
-			const timeoutId = setTimeout(() => controller.abort(), 5000);
+			if (globalSignal.aborted) {
+				return { id, result: { error: 'Cancelled' } as const };
+			}
+
+			const combinedController = new AbortController();
+			const timeoutId = setTimeout(() => combinedController.abort(), 5000);
+			const onGlobalAbort = () => {
+				clearTimeout(timeoutId);
+				combinedController.abort();
+			};
+			globalSignal.addEventListener('abort', onGlobalAbort, { once: true });
 
 			try {
 				const res = await fetch('/api/proxy', {
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },
 					body: JSON.stringify({ url1, url2 }),
-					signal: controller.signal
+					signal: combinedController.signal
 				});
 				clearTimeout(timeoutId);
+				globalSignal.removeEventListener('abort', onGlobalAbort);
 				const data = await res.json();
 				if (data.error) {
 					return { id, result: { error: data.error } as const };
@@ -441,6 +589,7 @@
 				};
 			} catch (e) {
 				clearTimeout(timeoutId);
+				globalSignal.removeEventListener('abort', onGlobalAbort);
 				const msg = e instanceof Error ? e.message : 'Unknown error';
 				return { id, result: { error: msg } as const };
 			}
@@ -529,15 +678,20 @@
 				isProcessingData = false;
 			}
 
-			for (const [id, result] of batchResults) {
-				if (!result.error) {
-					await logWatchedKeys(result.response1, result.response2, id);
+			if (!globalSignal.aborted) {
+				for (const [id, result] of batchResults) {
+					if (!result.error) {
+						await logWatchedKeys(result.response1, result.response2, id);
+					}
 				}
 			}
 		} catch (e) {
 			cmpState.error = e instanceof Error ? e.message : 'Unknown error';
 		} finally {
 			cmpState.loading = false;
+			if (!fetchAbortController?.signal.aborted) {
+				fetchAbortController = null;
+			}
 		}
 	}
 
@@ -652,20 +806,45 @@
 		<div class="grid grid-cols-12 gap-6">
 			<div class="col-span-3">
 				<label
-					for="api-endpoint"
+					for="api-endpoint-input"
 					class="mb-2 block text-xs font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400"
 					>API Endpoint</label
 				>
 				<div class="relative">
-					<select
-						id="api-endpoint"
-						bind:value={cmpState.selectedEndpoint}
-						class="w-full cursor-pointer appearance-none rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition-all focus:border-green-500 focus:ring-2 focus:ring-green-500/20 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:focus:ring-green-500/40"
-					>
-						{#each endpoints as endpoint (endpoint.id)}
-							<option value={endpoint.id}>{endpoint.name}</option>
-						{/each}
-					</select>
+					<input
+						id="api-endpoint-input"
+						type="text"
+						value={endpointInput}
+						oninput={onEndpointInput}
+						onfocus={onEndpointFocus}
+						onblur={onEndpointBlur}
+						onkeydown={onEndpointKeydown}
+						placeholder="Type to search endpoints..."
+						autocomplete="off"
+						class="w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-700 placeholder:text-gray-400 focus:border-green-500 focus:ring-2 focus:ring-green-500/20 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:placeholder:text-gray-600"
+					/>
+					{#if showEndpointSuggestions && filteredEndpoints.length > 0}
+						<div
+							class="absolute z-50 mt-1 max-h-60 w-full overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800"
+						>
+							{#each filteredEndpoints as endpoint, i (endpoint.id)}
+								<button
+									type="button"
+									onmousedown={() => selectEndpoint(endpoint.id)}
+									class="flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm transition-colors hover:bg-green-50 dark:hover:bg-green-900/20 {endpoint.id ===
+									cmpState.selectedEndpoint
+										? 'bg-green-50 font-medium text-green-700 dark:bg-green-900/20 dark:text-green-300'
+										: i === endpointHighlightIndex
+											? 'bg-green-100 dark:bg-green-900/30'
+											: 'text-gray-700 dark:text-gray-300'}"
+								>
+									<span>{endpoint.name}</span>
+									<span class="ml-auto text-xs text-gray-400 dark:text-gray-500">{endpoint.id}</span
+									>
+								</button>
+							{/each}
+						</div>
+					{/if}
 				</div>
 			</div>
 
@@ -855,33 +1034,55 @@
 				</div>
 			</div>
 
-			<button
-				onclick={fetchBoth}
-				disabled={cmpState.loading}
-				class="flex items-center gap-2 rounded-lg bg-green-600 px-5 py-2 text-sm font-medium text-white transition-all hover:bg-green-700 disabled:cursor-not-allowed disabled:opacity-50"
-				title="Run Comparison (Ctrl+Enter)"
-			>
+			<div class="flex items-center gap-2">
+				<button
+					onclick={() => {
+						if (!cmpState.loading) fetchBoth();
+					}}
+					disabled={cmpState.loading}
+					class="flex items-center gap-2 rounded-lg bg-green-600 px-5 py-2 text-sm font-medium text-white transition-all hover:bg-green-700 disabled:cursor-not-allowed disabled:opacity-50"
+					title="Run Comparison (Ctrl+Enter)"
+				>
+					{#if cmpState.loading}
+						<svg
+							class="h-4 w-4 animate-spin text-white"
+							xmlns="http://www.w3.org/2000/svg"
+							fill="none"
+							viewBox="0 0 24 24"
+						>
+							<circle
+								class="opacity-25"
+								cx="12"
+								cy="12"
+								r="10"
+								stroke="currentColor"
+								stroke-width="4"
+							></circle>
+							<path
+								class="opacity-75"
+								fill="currentColor"
+								d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+							></path>
+						</svg>
+						Running...
+					{:else}
+						<span>Run Comparison</span>
+						<kbd class="ml-1 rounded bg-green-500 px-1.5 py-0.5 text-xs font-normal">Ctrl+↵</kbd>
+					{/if}
+				</button>
 				{#if cmpState.loading}
-					<svg
-						class="h-4 w-4 animate-spin text-white"
-						xmlns="http://www.w3.org/2000/svg"
-						fill="none"
-						viewBox="0 0 24 24"
+					<button
+						onclick={stopFetch}
+						class="flex items-center gap-1.5 rounded-lg border border-red-300 bg-white px-4 py-2 text-sm font-medium text-red-600 transition-all hover:bg-red-50 dark:border-red-800 dark:bg-transparent dark:text-red-400 dark:hover:bg-red-900/20"
+						title="Stop fetching"
 					>
-						<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
-						></circle>
-						<path
-							class="opacity-75"
-							fill="currentColor"
-							d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-						></path>
-					</svg>
-					Running...
-				{:else}
-					<span>Run Comparison</span>
-					<kbd class="ml-1 rounded bg-green-500 px-1.5 py-0.5 text-xs font-normal">Ctrl+↵</kbd>
+						<svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+							<path d="M5 4h10a1 1 0 011 1v10a1 1 0 01-1 1H5a1 1 0 01-1-1V5a1 1 0 011-1z" />
+						</svg>
+						Stop
+					</button>
 				{/if}
-			</button>
+			</div>
 		</div>
 	</div>
 </div>

--- a/src/lib/components/KeyLogViewer.svelte
+++ b/src/lib/components/KeyLogViewer.svelte
@@ -601,9 +601,9 @@
 		void chartTimeRange;
 		void loggerState.idFilter;
 		if (showChart && traceKeyPath && loggerState.selectedEndpoint) {
-			fetchChartLogs();
+			untrack(() => fetchChartLogs());
 		} else {
-			chartLogs = [];
+			untrack(() => { chartLogs = []; });
 		}
 	});
 

--- a/src/lib/components/KeyLogViewer.svelte
+++ b/src/lib/components/KeyLogViewer.svelte
@@ -8,6 +8,7 @@
 	import { deepEqualIgnoreOrder, findIdValue } from '$lib/utils/jsonCompare';
 
 	import JsonViewer from '$lib/components/JsonViewer.svelte';
+	import TraceChart from '$lib/components/TraceChart.svelte';
 
 	let loggedEndpoints = $state<string[]>([]);
 
@@ -28,11 +29,16 @@
 		arrayDetailLog = null;
 	}
 
-	let traceKeyPath = $state('');
-	let showChart = $state(false);
-	let chartTimeRange = $state<'30m' | '1h' | '2h' | '6h' | '24h' | 'all'>('all');
+	let chartLoading = $state(false);
 	let limitInput = $state(loggerState.limit);
 	let chartLogs = $state<KeyLogEntry[]>([]);
+
+	// chart state lives on the singleton loggerState so it survives remounts.
+	// Read via these derived aliases; write via loggerState.xxx in handlers.
+	let traceKeyPath = $derived(loggerState.traceKeyPath);
+	let showChart = $derived(loggerState.showChart);
+	let chartSelectedLine = $derived(loggerState.chartSelectedLine);
+	let chartTimeRange = $derived(loggerState.chartTimeRange);
 
 	const matchCache = $derived.by(() => {
 		const map = new SvelteMap<number, boolean>();
@@ -548,6 +554,10 @@
 		const capturedEndpoint = loggerState.selectedEndpoint;
 		const capturedKey = traceKeyPath;
 		const capturedIdFilter = loggerState.idFilter;
+		// Only show the full-height spinner on the very first load (no data yet).
+		// Background refreshes update silently to avoid hide-and-appear flicker.
+		const isFirstLoad = chartLogs.length === 0;
+		if (isFirstLoad) chartLoading = true;
 		try {
 			let url = `/api/keylog?endpoint=${encodeURIComponent(capturedEndpoint)}&keyPath=${encodeURIComponent(capturedKey)}`;
 			const isLive = loggerState.timeRange === 'live';
@@ -571,9 +581,17 @@
 			const res = await fetch(url);
 			if (capturedEndpoint !== loggerState.selectedEndpoint || capturedKey !== traceKeyPath) return;
 			const data = await res.json();
-			chartLogs = data.logs || [];
+			const newLogs: KeyLogEntry[] = data.logs || [];
+			// Skip reassignment when data is unchanged to avoid chart flicker on every poll.
+			const same =
+				newLogs.length === chartLogs.length &&
+				(newLogs.length === 0 ||
+					newLogs[newLogs.length - 1]?.id === chartLogs[chartLogs.length - 1]?.id);
+			if (!same) chartLogs = newLogs;
 		} catch (e) {
 			console.error('Failed to fetch chart logs:', e);
+		} finally {
+			chartLoading = false;
 		}
 	}
 
@@ -1002,7 +1020,7 @@
 							Trace:
 						</div>
 						<select
-							bind:value={traceKeyPath}
+							bind:value={loggerState.traceKeyPath}
 							class="rounded-lg border border-gray-200 bg-gray-50 px-2 py-1.5 text-xs font-medium text-gray-700 focus:border-green-500 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300"
 						>
 							<option value="">Select key...</option>
@@ -1012,7 +1030,10 @@
 						</select>
 						<button
 							onclick={() => {
-								if (traceKeyPath) showChart = !showChart;
+								if (loggerState.traceKeyPath) {
+									loggerState.showChart = !loggerState.showChart;
+									loggerState.chartSelectedLine = null;
+								}
 							}}
 							disabled={!traceKeyPath}
 							class="flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-all {showChart &&
@@ -1073,19 +1094,7 @@
 	</div>
 
 	<!-- Chart -->
-	{#if showChart && traceKeyPath && chartData.entries.length > 1}
-		{@const pad = { top: 20, right: 16, bottom: 28, left: 48 }}
-		{@const cw = 400}
-		{@const ch = 220}
-		{@const iw = cw - pad.left - pad.right}
-		{@const ih = ch - pad.top - pad.bottom}
-		{@const scaleY = (v: number) => pad.top + ih - ((v - chartData.minVal) / chartData.range) * ih}
-		{@const scaleX = (ei: number) =>
-			pad.left + (ei / Math.max(chartData.entries.length - 1, 1)) * iw}
-		{@const yTicks = Array.from({ length: 5 }, (_, i) => {
-			const v = chartData.minVal + (chartData.range * i) / 4;
-			return { value: v, y: scaleY(v) };
-		})}
+	{#if showChart && traceKeyPath}
 		<div
 			class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800"
 		>
@@ -1101,7 +1110,13 @@
 						{#each ['30m', '1h', '2h', '6h', '24h', 'all'] as range (range)}
 							<button
 								onclick={() =>
-									(chartTimeRange = range as '30m' | '1h' | '2h' | '6h' | '24h' | 'all')}
+									(loggerState.chartTimeRange = range as
+										| '30m'
+										| '1h'
+										| '2h'
+										| '6h'
+										| '24h'
+										| 'all')}
 								class="rounded-md px-2.5 py-1.5 text-xs font-medium transition-all {chartTimeRange ===
 								range
 									? 'bg-white text-green-700 shadow-sm dark:bg-green-900/30 dark:text-green-300'
@@ -1111,165 +1126,98 @@
 							</button>
 						{/each}
 					</div>
-					<span class="text-xs text-gray-500">({chartData.entries.length} pts)</span>
+					<span class="text-xs text-gray-500">
+						{#if chartLoading}
+							<span class="flex items-center gap-1">
+								<svg class="h-3 w-3 animate-spin text-gray-400" viewBox="0 0 24 24" fill="none">
+									<circle
+										class="opacity-25"
+										cx="12"
+										cy="12"
+										r="10"
+										stroke="currentColor"
+										stroke-width="4"
+									/>
+									<path
+										class="opacity-75"
+										fill="currentColor"
+										d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+									/>
+								</svg>
+								Loading…
+							</span>
+						{:else}
+							({chartData.entries.length} pts)
+						{/if}
+					</span>
 				</div>
 			</div>
-			{#if chartData.hasNumeric}
-				<div class="grid grid-cols-2 gap-6">
-					<div>
-						<h4
-							class="mb-2 text-xs font-bold tracking-wide text-green-600 uppercase dark:text-green-400"
-						>
-							Server 1
-						</h4>
-						<svg viewBox="0 0 {cw} {ch}" class="w-full">
-							{#each yTicks as tick (tick.value)}
-								<line
-									x1={pad.left}
-									x2={cw - pad.right}
-									y1={tick.y}
-									y2={tick.y}
-									stroke="currentColor"
-									class="text-gray-200 dark:text-gray-700"
-									stroke-width="1"
-								/>
-							{/each}
-							{#each yTicks as tick (tick.value)}
-								<text
-									x={pad.left - 4}
-									y={tick.y + 3}
-									text-anchor="end"
-									class="fill-gray-500 text-[9px] dark:fill-gray-400"
-								>
-									{tick.value.toFixed(1)}
-								</text>
-							{/each}
-							<clipPath id="clip-s1">
-								<rect x={pad.left} y={pad.top} width={iw} height={ih} />
-							</clipPath>
-							<g clip-path="url(#clip-s1)">
-								{#each chartData.s1.series as s, si (si)}
-									<polyline
-										points={s.points.map((p) => `${scaleX(p.x)},${scaleY(p.y)}`).join(' ')}
-										fill="none"
-										stroke={S1_COLORS[si % S1_COLORS.length]}
-										stroke-width="2"
-										stroke-linejoin="round"
-										stroke-linecap="round"
-									/>
-								{/each}
-							</g>
-							{#if chartData.s1.series.length > 1}
-								<text
-									x={pad.left + 4}
-									y={pad.top - 4}
-									class="fill-gray-400 text-[8px] dark:fill-gray-500"
-								>
-									{chartData.s1.series.length} lines
-								</text>
-							{/if}
-							{#if chartData.s1.series.length > 1}
-								<g transform="translate({pad.left}, {ch - 16})">
-									{#each chartData.s1.series.slice(0, 6) as s, si (si)}
-										<line
-											x1={si * 50}
-											y1={0}
-											x2={si * 50 + 14}
-											y2={0}
-											stroke={S1_COLORS[si % S1_COLORS.length]}
-											stroke-width="2"
-										/>
-										<text
-											x={si * 50 + 16}
-											y={3}
-											class="fill-gray-500 text-[8px] dark:fill-gray-400"
-										>
-											{s.label}
-										</text>
-									{/each}
-								</g>
-							{/if}
-						</svg>
-					</div>
-					<div>
-						<h4
-							class="mb-2 text-xs font-bold tracking-wide text-orange-600 uppercase dark:text-orange-400"
-						>
-							Server 2
-						</h4>
-						<svg viewBox="0 0 {cw} {ch}" class="w-full">
-							{#each yTicks as tick (tick.value)}
-								<line
-									x1={pad.left}
-									x2={cw - pad.right}
-									y1={tick.y}
-									y2={tick.y}
-									stroke="currentColor"
-									class="text-gray-200 dark:text-gray-700"
-									stroke-width="1"
-								/>
-							{/each}
-							{#each yTicks as tick (tick.value)}
-								<text
-									x={pad.left - 4}
-									y={tick.y + 3}
-									text-anchor="end"
-									class="fill-gray-500 text-[9px] dark:fill-gray-400"
-								>
-									{tick.value.toFixed(1)}
-								</text>
-							{/each}
-							<clipPath id="clip-s2">
-								<rect x={pad.left} y={pad.top} width={iw} height={ih} />
-							</clipPath>
-							<g clip-path="url(#clip-s2)">
-								{#each chartData.s2.series as s, si (si)}
-									<polyline
-										points={s.points.map((p) => `${scaleX(p.x)},${scaleY(p.y)}`).join(' ')}
-										fill="none"
-										stroke={S2_COLORS[si % S2_COLORS.length]}
-										stroke-width="2"
-										stroke-linejoin="round"
-										stroke-linecap="round"
-									/>
-								{/each}
-							</g>
-							{#if chartData.s2.series.length > 1}
-								<text
-									x={pad.left + 4}
-									y={pad.top - 4}
-									class="fill-gray-400 text-[8px] dark:fill-gray-500"
-								>
-									{chartData.s2.series.length} lines
-								</text>
-							{/if}
-							{#if chartData.s2.series.length > 1}
-								<g transform="translate({pad.left}, {ch - 16})">
-									{#each chartData.s2.series.slice(0, 6) as s, si (si)}
-										<line
-											x1={si * 50}
-											y1={0}
-											x2={si * 50 + 14}
-											y2={0}
-											stroke={S2_COLORS[si % S2_COLORS.length]}
-											stroke-width="2"
-										/>
-										<text
-											x={si * 50 + 16}
-											y={3}
-											class="fill-gray-500 text-[8px] dark:fill-gray-400"
-										>
-											{s.label}
-										</text>
-									{/each}
-								</g>
-							{/if}
-						</svg>
-					</div>
+			{#if chartLoading}
+				<div
+					class="flex flex-col items-center justify-center gap-3 py-16 text-sm text-gray-400 dark:text-gray-500"
+				>
+					<svg
+						class="h-7 w-7 animate-spin text-green-500 dark:text-green-400"
+						viewBox="0 0 24 24"
+						fill="none"
+					>
+						<circle
+							class="opacity-25"
+							cx="12"
+							cy="12"
+							r="10"
+							stroke="currentColor"
+							stroke-width="4"
+						/>
+						<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+					</svg>
+					<span>Loading trace data…</span>
 				</div>
-			{:else}
+			{:else if chartData.entries.length <= 1}
+				<div
+					class="flex flex-col items-center justify-center gap-2 py-16 text-sm text-gray-400 dark:text-gray-500"
+				>
+					<svg
+						class="h-8 w-8 opacity-40"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="1.5"
+						><path stroke-linecap="round" stroke-linejoin="round" d="M3 12h3l3-8 4 16 3-8h5" /></svg
+					>
+					<span>No data points for this key in the selected range.</span>
+					<span class="text-xs">Try a wider time window or switch the key.</span>
+				</div>
+			{:else if !chartData.hasNumeric}
 				<div class="flex items-center justify-center py-8 text-sm text-gray-400 dark:text-gray-500">
 					Values are not numeric — chart cannot be rendered
+				</div>
+			{:else}
+				<div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+					<TraceChart
+						series={chartData.s1.series}
+						entries={chartData.entries}
+						colors={S1_COLORS}
+						minVal={chartData.minVal}
+						maxVal={chartData.maxVal}
+						range={chartData.range}
+						title="Server 1"
+						accentClass="text-green-600 dark:text-green-400"
+						bind:selectedLine={loggerState.chartSelectedLine}
+						onrefresh={fetchChartLogs}
+					/>
+					<TraceChart
+						series={chartData.s2.series}
+						entries={chartData.entries}
+						colors={S2_COLORS}
+						minVal={chartData.minVal}
+						maxVal={chartData.maxVal}
+						range={chartData.range}
+						title="Server 2"
+						accentClass="text-orange-600 dark:text-orange-400"
+						bind:selectedLine={loggerState.chartSelectedLine}
+						onrefresh={fetchChartLogs}
+					/>
 				</div>
 			{/if}
 		</div>

--- a/src/lib/components/KeyLogViewer.svelte
+++ b/src/lib/components/KeyLogViewer.svelte
@@ -603,7 +603,9 @@
 		if (showChart && traceKeyPath && loggerState.selectedEndpoint) {
 			untrack(() => fetchChartLogs());
 		} else {
-			untrack(() => { chartLogs = []; });
+			untrack(() => {
+				chartLogs = [];
+			});
 		}
 	});
 

--- a/src/lib/components/KeyLogViewer.svelte
+++ b/src/lib/components/KeyLogViewer.svelte
@@ -37,7 +37,6 @@
 	// Read via these derived aliases; write via loggerState.xxx in handlers.
 	let traceKeyPath = $derived(loggerState.traceKeyPath);
 	let showChart = $derived(loggerState.showChart);
-	let chartSelectedLine = $derived(loggerState.chartSelectedLine);
 	let chartTimeRange = $derived(loggerState.chartTimeRange);
 
 	const matchCache = $derived.by(() => {

--- a/src/lib/components/TraceChart.svelte
+++ b/src/lib/components/TraceChart.svelte
@@ -1,0 +1,617 @@
+<script lang="ts" module>
+	export interface TraceSeries {
+		label: string;
+		points: { x: number; y: number }[];
+	}
+	export interface TraceEntry {
+		timestamp: string;
+	}
+</script>
+
+<script lang="ts">
+	interface Props {
+		series: TraceSeries[];
+		entries: TraceEntry[];
+		colors: string[];
+		minVal: number;
+		maxVal: number;
+		range: number;
+		title: string;
+		accentClass: string;
+		selectedLine?: number | null;
+		onrefresh?: () => void;
+	}
+
+	let {
+		series,
+		entries,
+		colors,
+		minVal,
+		range,
+		title,
+		accentClass,
+		selectedLine = $bindable<number | null>(null),
+		onrefresh
+	}: Props = $props();
+
+	// unique, id-safe suffix for gradient/clip ids (space broke url() refs before)
+	const randSuffix = Math.random().toString(36).slice(2, 7);
+	const uid = $derived(title.toLowerCase().replace(/[^a-z0-9]/g, '-') + '-' + randSuffix);
+
+	const pad = { top: 24, right: 18, bottom: 30, left: 46 };
+	const cw = 420;
+	const ch = 240;
+	const iw = cw - pad.left - pad.right;
+	const ih = ch - pad.top - pad.bottom;
+
+	// view window in entry-index space
+	let viewLo = $state(0);
+	let viewHi = $state(0);
+
+	// Initialize the view once when data first appears; never reset on subsequent
+	// appends (that would discard the user's zoom/pan and cause flicker).
+	let prevLen = 0;
+	$effect(() => {
+		const n = Math.max(entries.length - 1, 0);
+		if (prevLen === 0 && n > 0) {
+			viewLo = 0;
+			viewHi = n;
+		} else if (entries.length === 0) {
+			viewLo = 0;
+			viewHi = 0;
+		}
+		// when at full view and data grows, follow the new tail
+		if (viewLo <= 1e-6 && viewHi >= prevLen - 1 - 1e-6 && n > viewHi) {
+			viewHi = n;
+		}
+		prevLen = entries.length;
+	});
+
+	const span = $derived(Math.max(viewHi - viewLo, 1e-6));
+
+	// "Nice" Y axis: round min/max out to human-friendly numbers (1, 2, 5 × 10^n)
+	// and pick a clean step so ticks read like -50, -45, … 75, 80 instead of
+	// raw data-driven decimals. Auto-rescales to the visible data when zoomed
+	// so zooming in shows accurate Y detail.
+	function niceNum(rangeVal: number, round: boolean): number {
+		const exp = Math.floor(Math.log10(rangeVal || 1));
+		const f = rangeVal / Math.pow(10, exp);
+		let nf: number;
+		if (round) {
+			if (f < 1.5) nf = 1;
+			else if (f < 3) nf = 2;
+			else if (f < 7) nf = 5;
+			else nf = 10;
+		} else {
+			if (f <= 1) nf = 1;
+			else if (f <= 2) nf = 2;
+			else if (f <= 5) nf = 5;
+			else nf = 10;
+		}
+		return nf * Math.pow(10, exp);
+	}
+
+	const yAxis = $derived.by(() => {
+		// gather Y values from visible points within the current zoom window
+		let lo = Infinity;
+		let hi = -Infinity;
+		for (const { s } of activeSeries) {
+			for (const pt of s.points) {
+				if (pt.x < viewLo - 1 || pt.x > viewHi + 1) continue;
+				if (pt.y < lo) lo = pt.y;
+				if (pt.y > hi) hi = pt.y;
+			}
+		}
+		if (!Number.isFinite(lo) || !Number.isFinite(hi)) {
+			lo = minVal;
+			hi = minVal + (range || 1);
+		}
+		if (lo === hi) {
+			lo -= 1;
+			hi += 1;
+		}
+		const tickCount = 5;
+		const rawRange = hi - lo || 1;
+		const niceRange = niceNum(rawRange, false);
+		const step = niceNum(niceRange / (tickCount - 1), true);
+		const niceMin = Math.floor(lo / step) * step;
+		const niceMax = Math.ceil(hi / step) * step;
+		const ticks: number[] = [];
+		for (let v = niceMin; v <= niceMax + step * 1e-6; v += step) {
+			ticks.push(Math.abs(v) < step * 1e-6 ? 0 : v);
+		}
+		const niceRealRange = niceMax - niceMin || 1;
+		return { ticks, niceMin, niceMax, niceRealRange };
+	});
+
+	const scaleY = (v: number) =>
+		pad.top + ih - ((v - yAxis.niceMin) / (yAxis.niceRealRange || 1)) * ih;
+	const scaleX = (ei: number) => pad.left + ((ei - viewLo) / span) * iw;
+
+	const yTicks = $derived(yAxis.ticks.map((value) => ({ value, y: scaleY(value) })));
+
+	// smart number formatter: keep integers clean, trim trailing zeros for
+	// small decimals, compact large numbers (1234 -> 1.2k, 2000000 -> 2M).
+	function fmt(v: number): string {
+		const abs = Math.abs(v);
+		if (abs >= 1_000_000) return (v / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'M';
+		if (abs >= 10_000) return (v / 1000).toFixed(1).replace(/\.0$/, '') + 'k';
+		if (abs >= 1000) return v.toFixed(0);
+		if (Number.isInteger(v)) return v.toString();
+		if (abs >= 10) return v.toFixed(1);
+		if (abs >= 1) return v.toFixed(2);
+		return v.toFixed(3);
+	}
+
+	const xTicks = $derived.by(() => {
+		const n = 5;
+		const out: { label: string; x: number; ei: number }[] = [];
+		for (let i = 0; i <= n; i++) {
+			const ei = viewLo + (span * i) / n;
+			out.push({ ei, x: scaleX(ei), label: Math.round(ei).toString() });
+		}
+		return out;
+	});
+
+	// selection model: selectedLine === null => all visible; otherwise only that line
+	const effVisible = $derived(
+		series.map((_, i) => (selectedLine === null ? true : i === selectedLine))
+	);
+	const activeSeries = $derived(series.map((s, i) => ({ s, i })).filter(({ i }) => effVisible[i]));
+
+	function selectLine(i: number) {
+		selectedLine = selectedLine === i ? null : i;
+	}
+
+	function showAll() {
+		selectedLine = null;
+	}
+
+	// zoom helpers
+	function zoomAt(centerEi: number, factor: number) {
+		const n = Math.max(entries.length - 1, 0);
+		const minSpan = n > 0 ? 1 : 0;
+		const maxSpan = n;
+		let newSpan = Math.min(Math.max(span / factor, minSpan), maxSpan);
+		let lo = centerEi - (newSpan * (centerEi - viewLo)) / span;
+		let hi = lo + newSpan;
+		if (lo < 0) {
+			hi -= lo;
+			lo = 0;
+		}
+		if (hi > n) {
+			lo -= hi - n;
+			hi = n;
+		}
+		if (lo < 0) lo = 0;
+		if (n === 0) {
+			lo = 0;
+			hi = 0;
+		}
+		viewLo = lo;
+		viewHi = hi;
+	}
+
+	function zoomButton(factor: number) {
+		zoomAt((viewLo + viewHi) / 2, factor);
+	}
+
+	function resetView() {
+		const n = Math.max(entries.length - 1, 0);
+		viewLo = 0;
+		viewHi = n;
+	}
+
+	const isZoomed = $derived(span < Math.max(entries.length - 1, 0) - 1e-6);
+
+	// wheel zoom
+	function onWheel(e: WheelEvent) {
+		e.preventDefault();
+		if (!svgEl) return;
+		const rect = svgEl.getBoundingClientRect();
+		const px = ((e.clientX - rect.left) / rect.width) * cw;
+		const ei = viewLo + ((px - pad.left) / iw) * span;
+		zoomAt(ei, e.deltaY > 0 ? 1 / 1.2 : 1.2);
+	}
+
+	// pan
+	let dragging = $state(false);
+	let moved = $state(false);
+	let dragStartX = 0;
+	let dragStartLo = 0;
+	let dragStartHi = 0;
+
+	function onPointerDown(e: PointerEvent) {
+		dragging = true;
+		moved = false;
+		dragStartX = e.clientX;
+		dragStartLo = viewLo;
+		dragStartHi = viewHi;
+		svgEl?.setPointerCapture(e.pointerId);
+	}
+
+	function onPointerMove(e: PointerEvent) {
+		updateHover(e);
+		if (!dragging) return;
+		const rect = svgEl!.getBoundingClientRect();
+		const dxPx = ((e.clientX - dragStartX) / rect.width) * cw;
+		if (Math.abs(e.clientX - dragStartX) > 3) moved = true;
+		const dEi = (dxPx / iw) * span;
+		const n = Math.max(entries.length - 1, 0);
+		let lo = dragStartLo - dEi;
+		let hi = dragStartHi - dEi;
+		if (lo < 0) {
+			hi -= lo;
+			lo = 0;
+		}
+		if (hi > n) {
+			lo -= hi - n;
+			hi = n;
+		}
+		if (lo < 0) lo = 0;
+		viewLo = lo;
+		viewHi = hi;
+	}
+
+	function onPointerUp(e: PointerEvent) {
+		dragging = false;
+		try {
+			svgEl?.releasePointerCapture(e.pointerId);
+		} catch {
+			// ignore
+		}
+	}
+
+	// hover crosshair + tooltip — all reactive state
+	let svgEl = $state<SVGSVGElement | null>(null);
+	let crosshairPx = $state<number | null>(null);
+	// Explicit hover data state (avoids derived chain issues)
+	let hoverData = $state<{ x: number; value: number | null; delta: number | null }[]>([]);
+
+	function updateHover(e: PointerEvent) {
+		if (!svgEl) return;
+		const rect = svgEl.getBoundingClientRect();
+		const px = ((e.clientX - rect.left) / rect.width) * cw;
+		if (px < pad.left || px > cw - pad.right) {
+			crosshairPx = null;
+			hoverData = [];
+			return;
+		}
+		crosshairPx = px;
+		const f = viewLo + ((px - pad.left) / iw) * span;
+		hoverData = activeSeries.map(({ s }) => {
+			if (!s || s.points.length === 0) {
+				return { x: 0, value: null as number | null, delta: null as number | null };
+			}
+			let nearest = s.points[0];
+			let bestDist = Math.abs(s.points[0].x - f);
+			for (const pt of s.points) {
+				const d = Math.abs(pt.x - f);
+				if (d < bestDist) {
+					bestDist = d;
+					nearest = pt;
+				}
+			}
+			const idx = s.points.indexOf(nearest);
+			const value = nearest.y;
+			const delta = idx > 0 ? value - s.points[idx - 1].y : null;
+			return { x: nearest.x, value, delta };
+		});
+	}
+
+	function clearHover() {
+		crosshairPx = null;
+		hoverData = [];
+	}
+
+	const tooltipLeft = $derived(crosshairPx !== null && crosshairPx > cw * 0.62);
+	const tooltipLeftPct = $derived(crosshairPx !== null ? (crosshairPx / cw) * 100 : 0);
+
+	// build a smooth path for a series (Catmull-Rom -> bezier)
+	function smoothPath(pts: { x: number; y: number }[]): string {
+		if (pts.length === 0) return '';
+		if (pts.length === 1) return `M ${scaleX(pts[0].x)},${scaleY(pts[0].y)}`;
+		let d = `M ${scaleX(pts[0].x)},${scaleY(pts[0].y)}`;
+		for (let i = 0; i < pts.length - 1; i++) {
+			const p0 = pts[i - 1] ?? pts[i];
+			const p1 = pts[i];
+			const p2 = pts[i + 1];
+			const p3 = pts[i + 2] ?? p2;
+			const c1x = scaleX(p1.x) + (scaleX(p2.x) - scaleX(p0.x)) / 6;
+			const c1y = scaleY(p1.y) + (scaleY(p2.y) - scaleY(p0.y)) / 6;
+			const c2x = scaleX(p2.x) - (scaleX(p3.x) - scaleX(p1.x)) / 6;
+			const c2y = scaleY(p2.y) - (scaleY(p3.y) - scaleY(p1.y)) / 6;
+			d += ` C ${c1x},${c1y} ${c2x},${c2y} ${scaleX(p2.x)},${scaleY(p2.y)}`;
+		}
+		return d;
+	}
+
+	// area path (line + baseline) for subtle gradient fill under the only visible series
+	function areaPath(pts: { x: number; y: number }[]): string {
+		if (pts.length === 0) return '';
+		const line = smoothPath(pts);
+		const baseline = scaleY(minVal);
+		return `${line} L ${scaleX(pts[pts.length - 1].x)},${baseline} L ${scaleX(pts[0].x)},${baseline} Z`;
+	}
+</script>
+
+<div class="flex h-full flex-col gap-2">
+	<!-- header: title + controls -->
+	<div class="flex items-start justify-between gap-3">
+		<div class="flex items-center gap-2">
+			<span class="inline-block h-2 w-2 rounded-full {accentClass} bg-current"></span>
+			<h4 class="text-sm font-semibold text-gray-800 dark:text-gray-100">{title}</h4>
+			<span
+				class="rounded-full bg-gray-100 px-1.5 py-0.5 text-[9px] font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+			>
+				{activeSeries.length}/{series.length}
+			</span>
+		</div>
+		<div class="flex items-center gap-1">
+			<button
+				type="button"
+				onclick={() => zoomButton(1.6)}
+				title="Zoom in"
+				aria-label="Zoom in"
+				class="grid h-7 w-7 place-items-center rounded-lg border border-gray-200 bg-white text-gray-600 shadow-sm transition hover:bg-gray-50 hover:text-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
+			>
+				<svg
+					class="h-3.5 w-3.5"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2.5"
+					stroke-linecap="round"><path d="M12 5v14M5 12h14" /></svg
+				>
+			</button>
+			<button
+				type="button"
+				onclick={() => zoomButton(1 / 1.6)}
+				title="Zoom out"
+				aria-label="Zoom out"
+				class="grid h-7 w-7 place-items-center rounded-lg border border-gray-200 bg-white text-gray-600 shadow-sm transition hover:bg-gray-50 hover:text-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
+			>
+				<svg
+					class="h-3.5 w-3.5"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2.5"
+					stroke-linecap="round"><path d="M5 12h14" /></svg
+				>
+			</button>
+			{#if isZoomed}
+				<button
+					type="button"
+					onclick={resetView}
+					title="Reset zoom"
+					aria-label="Reset zoom"
+					class="grid h-7 w-7 place-items-center rounded-lg border border-gray-200 bg-white text-gray-600 shadow-sm transition hover:bg-gray-50 hover:text-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
+				>
+					<svg
+						class="h-3.5 w-3.5"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2.2"
+						stroke-linecap="round"
+						stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7L3 8" /><path d="M3 3v5h5" /></svg
+					>
+				</button>
+			{/if}
+			{#if onrefresh}
+				<button
+					type="button"
+					onclick={() => onrefresh()}
+					title="Refresh chart data"
+					aria-label="Refresh chart data"
+					class="grid h-7 w-7 place-items-center rounded-lg border border-gray-200 bg-white text-gray-600 shadow-sm transition hover:bg-gray-50 hover:text-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
+				>
+					<svg
+						class="h-3.5 w-3.5"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2.2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" /><path
+							d="M21 3v5h-5"
+						/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" /><path
+							d="M3 21v-5h5"
+						/></svg
+					>
+				</button>
+			{/if}
+		</div>
+	</div>
+
+	<!-- chart -->
+	<div class="relative flex-1">
+		<svg
+			bind:this={svgEl}
+			viewBox="0 0 {cw} {ch}"
+			class="w-full touch-none select-none {dragging && moved
+				? 'cursor-grabbing'
+				: 'cursor-crosshair'}"
+			onwheel={onWheel}
+			onpointerdown={onPointerDown}
+			onpointermove={onPointerMove}
+			onpointerup={onPointerUp}
+			onpointercancel={onPointerUp}
+			onpointerleave={() => {
+				clearHover();
+				dragging = false;
+			}}
+		>
+			<defs>
+				{#each series as _, i (i)}
+					<linearGradient id="line-{uid}-{i}" x1="0" y1="0" x2="0" y2="1">
+						<stop offset="0%" stop-color={colors[i % colors.length]} stop-opacity="0.16" />
+						<stop offset="100%" stop-color={colors[i % colors.length]} stop-opacity="0" />
+					</linearGradient>
+				{/each}
+				<clipPath id="clip-{uid}">
+					<rect x={pad.left} y={pad.top - 6} width={iw} height={ih + 12} />
+				</clipPath>
+			</defs>
+
+			<!-- horizontal grid -->
+			{#each yTicks as tick (tick.value)}
+				<line
+					x1={pad.left}
+					x2={cw - pad.right}
+					y1={tick.y}
+					y2={tick.y}
+					stroke="currentColor"
+					class="text-gray-100 dark:text-gray-800"
+					stroke-width="1"
+				/>
+				<text
+					x={pad.left - 6}
+					y={tick.y + 3}
+					text-anchor="end"
+					class="fill-gray-400 text-[9px] tabular-nums dark:fill-gray-500"
+				>
+					{fmt(tick.value)}
+				</text>
+			{/each}
+
+			<!-- x ticks -->
+			{#each xTicks as tick (tick.ei)}
+				<text
+					x={tick.x}
+					y={ch - pad.bottom + 14}
+					text-anchor="middle"
+					class="fill-gray-400 text-[8px] tabular-nums dark:fill-gray-500"
+				>
+					{tick.label}
+				</text>
+			{/each}
+
+			<!-- series lines + data points -->
+			<g clip-path="url(#clip-{uid})">
+				{#each activeSeries as { s, i } (i)}
+					{#if activeSeries.length === 1}
+						<path d={areaPath(s.points)} fill="url(#line-{uid}-{i})" />
+					{/if}
+					<path
+						d={smoothPath(s.points)}
+						fill="none"
+						stroke={colors[i % colors.length]}
+						stroke-width="2.25"
+						stroke-linejoin="round"
+						stroke-linecap="round"
+						style="transition: d 0.3s ease"
+					/>
+					{#each s.points as p (p.x)}
+						<circle
+							cx={scaleX(p.x)}
+							cy={scaleY(p.y)}
+							r="2.5"
+							fill="white"
+							stroke={colors[i % colors.length]}
+							stroke-width="1.5"
+							style="transition: cx 0.3s ease, cy 0.3s ease"
+						/>
+					{/each}
+				{/each}
+			</g>
+
+			<!-- hover crosshair (follows mouse smoothly) -->
+			{#if crosshairPx !== null}
+				<line
+					x1={crosshairPx}
+					x2={crosshairPx}
+					y1={pad.top - 4}
+					y2={ch - pad.bottom}
+					stroke="#94a3b8"
+					stroke-width="1"
+					stroke-dasharray="4,4"
+				/>
+				{#each activeSeries as { i }, ai (i)}
+					{#if hoverData[ai]?.value !== null && hoverData[ai]?.value !== undefined}
+						<circle
+							cx={scaleX(hoverData[ai].x)}
+							cy={scaleY(hoverData[ai].value)}
+							r="4.5"
+							fill={colors[i % colors.length]}
+							stroke="white"
+							stroke-width="2"
+						/>
+					{/if}
+				{/each}
+			{/if}
+		</svg>
+
+		<!-- floating tooltip card (no transition:fly — instant follow like trading apps) -->
+		{#if crosshairPx !== null && hoverData.length > 0}
+			<div
+				class="pointer-events-none absolute top-0 z-20 min-w-[150px] rounded-xl border border-gray-200/80 bg-white/95 px-3 py-2 text-xs shadow-xl backdrop-blur-sm dark:border-gray-700/80 dark:bg-gray-900/95"
+				style="left: {tooltipLeftPct}%; {tooltipLeft
+					? 'transform: translateX(-110%)'
+					: 'transform: translateX(14px)'}"
+			>
+				{#each activeSeries as { s, i }, ai (i)}
+					<div class="flex items-center gap-2 py-0.5">
+						<span class="h-2 w-2 rounded-full" style="background-color: {colors[i % colors.length]}"
+						></span>
+						<span class="font-mono text-[10px] text-gray-500 dark:text-gray-400">{s.label}</span>
+						<span class="ml-auto text-right">
+							<span class="font-semibold text-gray-800 tabular-nums dark:text-gray-100">
+								{hoverData[ai]?.value !== null && hoverData[ai]?.value !== undefined
+									? fmt(hoverData[ai].value)
+									: '—'}
+							</span>
+							{#if hoverData[ai]?.delta !== null && hoverData[ai]?.delta !== undefined && hoverData[ai].delta !== 0}
+								<span
+									class="ml-1 text-[10px] font-medium {hoverData[ai].delta > 0
+										? 'text-emerald-600 dark:text-emerald-400'
+										: 'text-rose-600 dark:text-rose-400'}"
+								>
+									{hoverData[ai].delta > 0 ? '↑' : '↓'}{fmt(Math.abs(hoverData[ai].delta))}
+								</span>
+							{/if}
+						</span>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+
+	<!-- legend / line picker -->
+	<div class="flex flex-wrap items-center gap-1.5">
+		{#if selectedLine !== null}
+			<button
+				type="button"
+				onclick={showAll}
+				class="rounded-full border border-gray-200 bg-white px-2.5 py-1 text-[10px] font-medium text-gray-600 shadow-sm transition hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
+			>
+				Show all
+			</button>
+		{/if}
+		{#each series as s, i (i)}
+			<button
+				type="button"
+				onclick={() => selectLine(i)}
+				title={selectedLine === i ? 'Click to show all lines' : 'Click to view only this line'}
+				class="flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[10px] font-medium transition
+					{selectedLine === null
+					? 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800'
+					: selectedLine === i
+						? 'border-transparent text-white shadow-sm'
+						: 'border-gray-200/60 bg-gray-50 text-gray-400 dark:border-gray-800 dark:bg-gray-900/50 dark:text-gray-600'}"
+				style={selectedLine === i ? `background-color: ${colors[i % colors.length]}` : ''}
+			>
+				<span class="h-2 w-2 rounded-full" style="background-color: {colors[i % colors.length]}"
+				></span>
+				<span class="font-mono">{s.label}</span>
+			</button>
+		{/each}
+	</div>
+	{#if series.length > 1}
+		<div class="text-[9px] text-gray-400 dark:text-gray-500">
+			Tap a line to view it alone · scroll to zoom · drag to pan
+		</div>
+	{/if}
+</div>

--- a/src/lib/panelState.svelte.ts
+++ b/src/lib/panelState.svelte.ts
@@ -264,6 +264,13 @@ export class LoggerState {
 
 	keyPaths = $state<string[]>([]);
 	selectedKeyPaths = $state(new SvelteSet<string>());
+
+	// Chart state lives here (module singleton) so it survives KeyLogViewer
+	// remounts when switching tabs or toggling split view.
+	traceKeyPath = $state('');
+	showChart = $state(false);
+	chartSelectedLine = $state<number | null>(null);
+	chartTimeRange = $state<'30m' | '1h' | '2h' | '6h' | '24h' | 'all'>('all');
 }
 
 export interface GtfsRtSnapshotEntry {
@@ -286,3 +293,59 @@ export const protobufState = new ProtobufState();
 export const gtfsStaticState = new GtfsStaticState();
 export const loggerState = new LoggerState();
 export const gtfsRtLogState = new GtfsRtLogState();
+
+// ---- Persistence: continuously save key comparator fields to localStorage so
+// they survive server restarts / page reloads. Loaded eagerly at module init. ----
+if (typeof localStorage !== 'undefined') {
+	const defaults = {
+		server1Base: 'http://localhost:4000/api/where/',
+		server2Base: 'https://unitrans-api.server.onebusawaycloud.com/api/where/'
+	};
+	if (localStorage.server1Base) comparatorState.server1Base = localStorage.server1Base;
+	else comparatorState.server1Base = defaults.server1Base;
+	if (localStorage.server2Base) comparatorState.server2Base = localStorage.server2Base;
+	else comparatorState.server2Base = defaults.server2Base;
+	if (localStorage.comparatorSelectedEndpoint) {
+		comparatorState.selectedEndpoint = localStorage.comparatorSelectedEndpoint;
+	}
+	if (localStorage.comparatorParams) {
+		try {
+			const saved = JSON.parse(localStorage.comparatorParams);
+			if (saved && typeof saved === 'object') comparatorState.params = saved;
+		} catch {
+			// ignore
+		}
+	}
+	if (localStorage.comparatorEndpointParams) {
+		try {
+			const saved = JSON.parse(localStorage.comparatorEndpointParams);
+			if (saved && typeof saved === 'object') comparatorState.endpointParams = saved;
+		} catch {
+			// ignore
+		}
+	}
+
+	$effect.root(() => {
+		$effect(() => {
+			const v = comparatorState.server1Base;
+			if (typeof localStorage !== 'undefined') localStorage.server1Base = v;
+		});
+		$effect(() => {
+			const v = comparatorState.server2Base;
+			if (typeof localStorage !== 'undefined') localStorage.server2Base = v;
+		});
+		$effect(() => {
+			const v = comparatorState.selectedEndpoint;
+			if (typeof localStorage !== 'undefined') localStorage.comparatorSelectedEndpoint = String(v);
+		});
+		$effect(() => {
+			const v = comparatorState.params;
+			if (typeof localStorage !== 'undefined') localStorage.comparatorParams = JSON.stringify(v);
+		});
+		$effect(() => {
+			const v = comparatorState.endpointParams;
+			if (typeof localStorage !== 'undefined')
+				localStorage.comparatorEndpointParams = JSON.stringify(v);
+		});
+	});
+}


### PR DESCRIPTION
Added

- New TraceChart.svelte with zoom (buttons + wheel), pan (drag),
  per-line click-to-solo, Catmull-Rom curves, smart Y-axis rescaling
- Fix infinite reactive loop (effects writing $state they read)
- Fix stale tooltip values (replace @const with $derived.by, then
  $state in event handler to avoid chain issues)
- Fix coordinate mapping inversion (iw/span swapped) so hover finds
  the correct nearest data point
- Lift selectedLine to parent via $bindable for cross-chart sync
- Persist chart state (showChart, traceKeyPath, selectedLine,
  timeRange) on LoggerState singleton to survive tab/split remounts
- Add continuous localStorage persistence for comparator fields
- Fix clip-path url() references (sanitize id for spaces)
- Add data-point dots, refresh button, glassy tooltip with trend arrows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Stop button to cancel in-progress comparisons.
  * Endpoint selection now supports search, filtering, keyboard navigation, and click-to-select.
  * Added interactive trace charts with zooming, panning, hover tooltips, legends, and multi-series support.
  * Added chart loading, empty, and non-numeric data states.
  * Improved watched-key logging for JSON paths containing array wildcards.

* **Improvements**
  * Comparison settings and chart preferences now persist between sessions.
  * Reduced chart flicker during refreshes and prevented duplicate comparison requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->