### PR TITLE
fix: migrate build-script allow-list to pnpm 11 allowBuilds

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
 	"private": true,
 	"version": "0.0.1",
 	"type": "module",
+	"engines": {
+		"node": ">=20.19.0"
+	},
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/package.json
+++ b/package.json
@@ -38,12 +38,6 @@
 		"typescript-eslint": "^8.53.0",
 		"vite": "^7.2.6"
 	},
-	"pnpm": {
-		"onlyBuiltDependencies": [
-			"better-sqlite3",
-			"esbuild"
-		]
-	},
 	"dependencies": {
 		"@codemirror/autocomplete": "^6.20.0",
 		"@codemirror/commands": "^6.10.1",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages:
+  - '*'
 allowBuilds:
   better-sqlite3: true
   esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 allowBuilds:
-  better-sqlite3: set this to true or false
-  esbuild: set this to true or false
-  protobufjs: set this to true or false
+  better-sqlite3: true
+  esbuild: true
+  protobufjs: true


### PR DESCRIPTION
## Why this PR

The current `pnpm.onlyBuiltDependencies` configuration is outdated. The official [pnpm 10.26 release notes](https://pnpm.io/blog/releases/10.26#allowbuilds) introduce `allowBuilds` as the preferred replacement for `onlyBuiltDependencies` and `ignoredBuiltDependencies`.

Updating this prevents `ERR_PNPM_IGNORED_BUILDS` for future contributors using newer pnpm versions and keeps the project aligned with the current pnpm configuration.

## Changes

* Replace `onlyBuiltDependencies` with `allowBuilds` in `pnpm-workspace.yaml`
* Remove the deprecated `pnpm.onlyBuiltDependencies` configuration
* Add Node.js `>=20.19.0` required by Vite 7